### PR TITLE
Contao 5.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,5 @@ Install the extension via composer: [trilobit-gmbh/contao-cookiebar-bundle](http
 Compatibility
 -------------
 
-- Contao version ~4.4 [^1]
-- Contao version ~4.9
 - Contao version ~4.13
-
-[^1]: Diese Contao-Version wird bei den nächsten Updates nicht mehr berücksichtigt. / This Contao version will no longer be included in the next updates.
+- Contao version ~5.0

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
-        "contao/core-bundle": "~4.4",
+        "php": "^7.4 || ^8.0",
+        "contao/core-bundle": "^4.13 || ^5.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Resources/contao/classes/CookieBar.php
+++ b/src/Resources/contao/classes/CookieBar.php
@@ -13,13 +13,13 @@
 
 namespace Trilobit\CookiebarBundle;
 
-use Contao\Controller;
 use Contao\DataContainer;
 use Contao\Frontend;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use Contao\PageRegular;
 use Contao\StringUtil;
+use Contao\System;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -118,17 +118,15 @@ class CookieBar extends Frontend
         $arrRootPage['cookieBarCookieDomain'] = !empty($arrRootPage['cookieBarCookieDomain']) ? $arrRootPage['cookieBarCookieDomain'] : '';
         $arrRootPage['cookieBarCookieExpiryDays'] = !empty($arrRootPage['cookieBarCookieExpiryDays']) ? $arrRootPage['cookieBarCookieExpiryDays'] : '30';
 
-        $arrPalette = [];
-
         $arrOptions = [
             'theme' => $arrRootPage['cookieBarTheme'],
             'content' => [
-                'header' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarHeader'])),
-                'message' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarMessage'])),
-                'dismiss' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarDismiss'])),
-                'link' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarLink'])),
-                'close' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarClose'])),
-                'href' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarHref'])),
+                'header' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarHeader'])),
+                'message' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarMessage'])),
+                'dismiss' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarDismiss'])),
+                'link' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarLink'])),
+                'close' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarClose'])),
+                'href' => trim(System::getContainer()->get('contao.insert_tag.parser')->replaceInline($arrRootPage['cookieBarHref'])),
             ],
             'type' => $arrRootPage['cookieBarType'],
             'layout' => $arrRootPage['cookieBarLayout'],
@@ -136,7 +134,7 @@ class CookieBar extends Frontend
             'cookie' => [
                 'name' => $arrRootPage['cookieBarCookieName'],
                 'path' => $arrRootPage['cookieBarCookiePath'],
-                'domain' => trim(Controller::replaceInsertTags($arrRootPage['cookieBarCookieDomain'])),
+                'domain' => trim($arrRootPage['cookieBarCookieDomain']),
                 'expiryDays' => (int) $arrRootPage['cookieBarCookieExpiryDays'],
             ],
         ];
@@ -168,7 +166,7 @@ class CookieBar extends Frontend
 
         $GLOBALS['TL_HEAD']['cookieconsent'] = "<script>\n"
             ."window.addEventListener(\"load\", function() {\n"
-            .'window.cookieconsent.initialise('.Controller::replaceInsertTags(json_encode($arrOptions)).");\n"
+            .'window.cookieconsent.initialise('.System::getContainer()->get('contao.insert_tag.parser')->replaceInline(json_encode($arrOptions)).");\n"
             ."});\n"
             .'</script>'
         ;

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -11,6 +11,7 @@
  * Register hook.
  */
 
+use Contao\System;
 use Trilobit\CookiebarBundle\CookieBar;
 
 $GLOBALS['TL_HOOKS']['generatePage'][] = [CookieBar::class, 'addCookieBar'];
@@ -20,6 +21,8 @@ define('TRILOBIT_COOKIEBAR_ASSETS', 'bundles/trilobitcookiebar/assets/build');
 /*
  * Add css
  */
-if (TL_MODE === 'BE') {
+$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+if (null !== $request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
     $GLOBALS['TL_CSS'][] = 'bundles/trilobitcookiebar/css/backend.css';
 }


### PR DESCRIPTION
This PR brings **Contao 5.x** compatibility. Unfortunately, the older versions of Contao 4.4 and 4.9 **can no longer be supported** with this build. 😢 
